### PR TITLE
Want OTel trace header to propagate

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,9 +7,9 @@ import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations
 
 const configDefaults = {
     ignoreNetworkEvents: true,
-    // propagateTraceHeaderCorsUrls: [
-    // /.+/g, // Regex to match your backend URLs. Update to the domains you wish to include.
-    // ]
+    propagateTraceHeaderCorsUrls: [
+    /jsonplaceholder.typicode.com/g, // Regex to match your backend URLs. Update to the domains you wish to include.
+    ]
 }
 
 const sdk = new HoneycombWebSDK({

--- a/src/pages/Tab1.tsx
+++ b/src/pages/Tab1.tsx
@@ -1,8 +1,23 @@
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonList, IonItem, IonLabel } from '@ionic/react';
 import ExploreContainer from '../components/ExploreContainer';
+import { useEffect, useState } from 'react';
 import './Tab1.css';
 
+interface Post {
+  id: number;
+  title: string;
+  body: string;
+}
+
 const Tab1: React.FC = () => {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    fetch('https://jsonplaceholder.typicode.com/posts?limit=5')
+      .then(response => response.json())
+      .then(data => setPosts(data.slice(0, 5)));
+  }, []);
+
   return (
     <IonPage>
       <IonHeader>
@@ -16,6 +31,16 @@ const Tab1: React.FC = () => {
             <IonTitle size="large">Tab 1</IonTitle>
           </IonToolbar>
         </IonHeader>
+        <IonList>
+          {posts.map(post => (
+            <IonItem key={post.id}>
+              <IonLabel>
+                <h2>{post.title}</h2>
+                <p>{post.body}</p>
+              </IonLabel>
+            </IonItem>
+          ))}
+        </IonList>
         <ExploreContainer name="Tab 1 page" />
       </IonContent>
     </IonPage>


### PR DESCRIPTION
## What is this?

Wanted to test out propagation of OTel trace header (in this case, more of a test of validating otel traces show up on externally hosted API endpoints).

## How to test it

Run it and look in your network inspector in browser. Validate that outbound calls to the `jsonplaceholder` API have o11y bits.